### PR TITLE
Prevent ResizeObserver loop limit error

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -24,7 +24,7 @@
     {
       "files": "tests/**/*-test.js",
       "options": {
-        "printWidth": 100
+        "printWidth": 90
       }
     }
   ]

--- a/addon/services/resize-observer.js
+++ b/addon/services/resize-observer.js
@@ -17,6 +17,7 @@ export default class ResizeObserverService extends Service {
   setup() {
     this.callbacks = null;
     this.observer = null;
+    this.rafID = null;
 
     if (typeof FastBoot !== 'undefined' || typeof window === 'undefined') {
       return;
@@ -100,20 +101,27 @@ export default class ResizeObserverService extends Service {
       return;
     }
 
+    window.cancelAnimationFrame(this.rafID);
     this.callbacks = new WeakMap();
     this.observer.disconnect();
   }
 
+  willDestroy() {
+    this.clear();
+  }
+
   @action
   handleResize(entries) {
-    for (const entry of entries) {
-      const callbacks = this.callbacks.get(entry.target);
+    this.rafID = requestAnimationFrame(() => {
+      for (const entry of entries) {
+        const callbacks = this.callbacks.get(entry.target);
 
-      if (callbacks) {
-        for (const callback of callbacks) {
-          callback(entry);
+        if (callbacks) {
+          for (const callback of callbacks) {
+            callback(entry);
+          }
         }
       }
-    }
+    });
   }
 }

--- a/tests/integration/modifiers/on-resize-test.js
+++ b/tests/integration/modifiers/on-resize-test.js
@@ -55,6 +55,19 @@ module('Integration | Modifier | on-resize', function (hooks) {
     assert.spy(this.onResize).notCalled('did not call onResize when size is not changed');
   });
 
+  test('prevents ResizeObserver loop limit related errors', async function (assert) {
+    assert.expect(0);
+    this.onResize = () => this.set('showText', true);
+
+    await render(hbs`
+      <div {{on-resize this.onResize}}>
+        {{if this.showText "Trigger ResizeObserver again"}}
+      </div>
+    `);
+
+    delay();
+  });
+
   test('using multiple modifiers for the same element', async function (assert) {
     const callback1 = sinon.spy().named('callback1');
     const callback2 = sinon.spy().named('callback2');

--- a/tests/integration/modifiers/on-resize-test.js
+++ b/tests/integration/modifiers/on-resize-test.js
@@ -8,6 +8,10 @@ import { delay, setSize } from '../../utils';
 module('Integration | Modifier | on-resize', function (hooks) {
   setupRenderingTest(hooks);
 
+  hooks.beforeEach(function () {
+    sinon.stub(window, 'requestAnimationFrame').callsFake(callback => callback());
+  });
+
   test('it works', async function (assert) {
     this.onResize = sinon.spy().named('onResize');
 
@@ -59,19 +63,6 @@ module('Integration | Modifier | on-resize', function (hooks) {
     await setSize(element, { width: 50 });
 
     assert.spy(this.onResize).notCalled('did not call onResize when size is not changed');
-  });
-
-  test('prevents ResizeObserver loop limit related errors', async function (assert) {
-    assert.expect(0);
-    this.onResize = () => this.set('showText', true);
-
-    await render(hbs`
-      <div {{on-resize this.onResize}}>
-        {{if this.showText "Trigger ResizeObserver again"}}
-      </div>
-    `);
-
-    delay();
   });
 
   test('using multiple modifiers for the same element', async function (assert) {
@@ -149,5 +140,19 @@ module('Integration | Modifier | on-resize', function (hooks) {
 
     assert.spy(callback1).notCalled();
     assert.spy(callback2).calledOnce();
+  });
+
+  test('prevents ResizeObserver loop limit related errors', async function (assert) {
+    assert.expect(0);
+    window.requestAnimationFrame.restore();
+    this.onResize = () => this.set('showText', true);
+
+    await render(hbs`
+      <div {{on-resize this.onResize}}>
+        {{if this.showText "Trigger ResizeObserver again"}}
+      </div>
+    `);
+
+    delay();
   });
 });

--- a/tests/integration/modifiers/on-resize-test.js
+++ b/tests/integration/modifiers/on-resize-test.js
@@ -29,7 +29,9 @@ module('Integration | Modifier | on-resize', function (hooks) {
       .calledOnce('called onResize on insert')
       .calledWithExactly([sinon.match.instanceOf(ResizeObserverEntry)])
       .calledWithExactly([sinon.match({ target: element })])
-      .calledWithExactly([sinon.match({ contentRect: sinon.match({ height: 100, width: 100 }) })]);
+      .calledWithExactly([
+        sinon.match({ contentRect: sinon.match({ height: 100, width: 100 }) }),
+      ]);
 
     this.onResize.resetHistory();
     await setSize(element, { width: 50 });
@@ -38,7 +40,9 @@ module('Integration | Modifier | on-resize', function (hooks) {
       .spy(this.onResize)
       .calledOnce('called onResize on width change')
       .calledWithExactly([sinon.match({ target: element })])
-      .calledWithExactly([sinon.match({ contentRect: sinon.match({ height: 100, width: 50 }) })]);
+      .calledWithExactly([
+        sinon.match({ contentRect: sinon.match({ height: 100, width: 50 }) }),
+      ]);
 
     this.onResize.resetHistory();
     await setSize(element, { height: 50 });
@@ -47,7 +51,9 @@ module('Integration | Modifier | on-resize', function (hooks) {
       .spy(this.onResize)
       .calledOnce('called onResize on height change')
       .calledWithExactly([sinon.match({ target: element })])
-      .calledWithExactly([sinon.match({ contentRect: sinon.match({ height: 50, width: 50 }) })]);
+      .calledWithExactly([
+        sinon.match({ contentRect: sinon.match({ height: 50, width: 50 }) }),
+      ]);
 
     this.onResize.resetHistory();
     await setSize(element, { width: 50 });

--- a/tests/unit/services/resize-observer-test.js
+++ b/tests/unit/services/resize-observer-test.js
@@ -176,6 +176,16 @@ module('Unit | Service | resize-observer', function (hooks) {
       this.disconnectSpy = sinon.stub(this.service.observer, 'disconnect');
     });
 
+    test('cancels animation frame', function (assert) {
+      const { service } = this;
+      const cancelAFSpy = sinon.stub(window, 'cancelAnimationFrame');
+
+      sinon.stub(this.service, 'rafID').value(123);
+      service.clear();
+
+      assert.spy(cancelAFSpy).calledOnce().calledWithExactly([123]);
+    });
+
     test('resets callbacks map and unobserve all elements', function (assert) {
       const { service, serviceCallbacks, disconnectSpy } = this;
 
@@ -200,6 +210,7 @@ module('Unit | Service | resize-observer', function (hooks) {
     hooks.beforeEach(function () {
       const service = this.owner.lookup('service:resize-observer');
       sinon.stub(service.observer, 'observe');
+      sinon.stub(window, 'requestAnimationFrame').callsFake(callback => callback());
 
       const banner = document.createElement('div');
       banner.callbacks = [

--- a/tests/unit/services/resize-observer-test.js
+++ b/tests/unit/services/resize-observer-test.js
@@ -60,7 +60,10 @@ module('Unit | Service | resize-observer', function (hooks) {
       observeSpy.reset();
       service.observe(element, newCallback);
 
-      assert.ok(service.callbacks.get(element).has(callback), 'still has the existing callback');
+      assert.ok(
+        service.callbacks.get(element).has(callback),
+        'still has the existing callback'
+      );
       assert.ok(service.callbacks.get(element).has(newCallback), 'added a new callback');
       assert.spy(observeSpy).notCalled();
     });
@@ -91,7 +94,11 @@ module('Unit | Service | resize-observer', function (hooks) {
 
       service.observe(element, callback);
 
-      assert.equal(service.callbacks.get(element).size, 1, 'has an element with a single callback');
+      assert.equal(
+        service.callbacks.get(element).size,
+        1,
+        'has an element with a single callback'
+      );
 
       service.unobserve(element, callback);
 
@@ -106,13 +113,22 @@ module('Unit | Service | resize-observer', function (hooks) {
       service.observe(element, callback);
       service.observe(element, targetCallback);
 
-      assert.ok(service.callbacks.get(element).has(targetCallback), 'has a target callback');
-      assert.ok(service.callbacks.get(element).has(callback), 'has a non-target callback');
+      assert.ok(
+        service.callbacks.get(element).has(targetCallback),
+        'has a target callback'
+      );
+      assert.ok(
+        service.callbacks.get(element).has(callback),
+        'has a non-target callback'
+      );
 
       service.unobserve(element, targetCallback);
 
       assert.ok(service.callbacks.has(element), 'did not remove the element');
-      assert.notOk(service.callbacks.get(element).has(targetCallback), 'removed a target callback');
+      assert.notOk(
+        service.callbacks.get(element).has(targetCallback),
+        'removed a target callback'
+      );
       assert.ok(
         service.callbacks.get(element).has(callback),
         'did not remove a non-target callback'
@@ -126,7 +142,11 @@ module('Unit | Service | resize-observer', function (hooks) {
       service.observe(element, () => null);
       service.observe(element, () => null);
 
-      assert.equal(service.callbacks.get(element).size, 2, 'has an element with two callbacks');
+      assert.equal(
+        service.callbacks.get(element).size,
+        2,
+        'has an element with two callbacks'
+      );
 
       service.unobserve(element);
 
@@ -139,7 +159,10 @@ module('Unit | Service | resize-observer', function (hooks) {
 
       service.observe(element, callback);
 
-      assert.ok(service.callbacks.get(element).has(callback), 'has an element with a callback');
+      assert.ok(
+        service.callbacks.get(element).has(callback),
+        'has an element with a callback'
+      );
 
       sinon.stub(service, 'isEnabled').get(() => false);
       service.unobserve(element, callback);
@@ -157,7 +180,10 @@ module('Unit | Service | resize-observer', function (hooks) {
 
       service.observe(element, callback);
 
-      assert.ok(service.callbacks.get(element).has(callback), 'has an element with a callback');
+      assert.ok(
+        service.callbacks.get(element).has(callback),
+        'has an element with a callback'
+      );
 
       service.unobserve(wrongElement, callback);
 
@@ -222,13 +248,19 @@ module('Unit | Service | resize-observer', function (hooks) {
       service.observe(banner, banner.callbacks[1]);
 
       const modal = document.createElement('div');
-      modal.callbacks = [sinon.spy().named('modalCallback1'), sinon.spy().named('modalCallback2')];
+      modal.callbacks = [
+        sinon.spy().named('modalCallback1'),
+        sinon.spy().named('modalCallback2'),
+      ];
 
       service.observe(modal, modal.callbacks[0]);
       service.observe(modal, modal.callbacks[1]);
 
       const form = document.createElement('div');
-      form.callbacks = [sinon.spy().named('formCallback1'), sinon.spy().named('formCallback2')];
+      form.callbacks = [
+        sinon.spy().named('formCallback1'),
+        sinon.spy().named('formCallback2'),
+      ];
 
       service.observe(form, form.callbacks[0]);
       service.observe(form, form.callbacks[1]);


### PR DESCRIPTION
It happens when you trigger `ResizeObserver` observation in the same animation frame again. The `ResizeObserver` loop protection will move the observation to the next frame and fire an error event `ResizeObserver loop limit exceeded`. The error can be safely ignored, though it can still fail tests and make noise in services like Sentry.

An example with [`{{on-resize}}`](https://github.com/PrecisionNutrition/ember-on-resize-modifier) modifier:

```js
// inside of a component class...

showText = false;

@action
handleResize() {
  this.showText = true;
}
```

```hbs
<div {{on-resize this.handleResize}}>
  {{if this.showText "Rendering this text will resize the div element which will trigger observation again"}}
</div>
```