### PR TITLE
Switch from raf to error ignore for RO loop limit

### DIFF
--- a/addon/utils/ignore-ro-error.js
+++ b/addon/utils/ignore-ro-error.js
@@ -1,0 +1,27 @@
+const errorMessage = 'ResizeObserver loop limit exceeded';
+
+/**
+ * Ignores "ResizeObserver loop limit exceeded" error in Ember tests.
+ *
+ * This "error" is safe to ignore as it is just a warning message,
+ * telling that the "looping" observation will be skipped in the current frame,
+ * and will be delivered in the next one.
+ *
+ * For some reason, it is fired as an `error` event at `window` failing Ember
+ * tests and exploding Sentry with errors that must be ignored.
+ */
+export default function ignoreROError() {
+  if (typeof window.onerror !== 'function') {
+    return;
+  }
+
+  const onError = window.onerror;
+
+  window.onerror = (message, ...args) => {
+    if (message === errorMessage) {
+      return true;
+    } else {
+      onError(message, ...args);
+    }
+  };
+}

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,7 +2,7 @@
 
 const getChannelURL = require('ember-source-channel-url');
 
-module.exports = async function() {
+module.exports = async function () {
   return {
     useYarn: true,
     scenarios: [
@@ -10,80 +10,42 @@ module.exports = async function() {
         name: 'ember-lts-3.12',
         npm: {
           devDependencies: {
-            'ember-source': '~3.12.0'
-          }
-        }
+            'ember-source': '~3.12.0',
+          },
+        },
       },
       {
         name: 'ember-lts-3.16',
         npm: {
           devDependencies: {
-            'ember-source': '~3.16.0'
-          }
-        }
+            'ember-source': '~3.16.0',
+          },
+        },
       },
       {
         name: 'ember-release',
         npm: {
           devDependencies: {
-            'ember-source': await getChannelURL('release')
-          }
-        }
+            'ember-source': await getChannelURL('release'),
+          },
+        },
       },
       {
         name: 'ember-beta',
         npm: {
           devDependencies: {
-            'ember-source': await getChannelURL('beta')
-          }
-        }
+            'ember-source': await getChannelURL('beta'),
+          },
+        },
       },
       {
         name: 'ember-canary',
         npm: {
           devDependencies: {
-            'ember-source': await getChannelURL('canary')
-          }
-        }
-      },
-      // The default `.travis.yml` runs this scenario via `yarn test`,
-      // not via `ember try`. It's still included here so that running
-      // `ember try:each` manually or from a customized CI config will run it
-      // along with all the other scenarios.
-      {
-        name: 'ember-default',
-        npm: {
-          devDependencies: {}
-        }
-      },
-      {
-        name: 'ember-default-with-jquery',
-        env: {
-          EMBER_OPTIONAL_FEATURES: JSON.stringify({
-            'jquery-integration': true
-          })
+            'ember-source': await getChannelURL('canary'),
+          },
         },
-        npm: {
-          devDependencies: {
-            '@ember/jquery': '^0.5.1'
-          }
-        }
       },
-      {
-        name: 'ember-classic',
-        env: {
-          EMBER_OPTIONAL_FEATURES: JSON.stringify({
-            'application-template-wrapper': true,
-            'default-async-observers': false,
-            'template-only-glimmer-components': false
-          })
-        },
-        npm: {
-          ember: {
-            edition: 'classic'
-          }
-        }
-      }
-    ]
+    ],
   };
 };

--- a/tests/integration/modifiers/on-resize-test.js
+++ b/tests/integration/modifiers/on-resize-test.js
@@ -8,10 +8,6 @@ import { delay, setSize } from '../../utils';
 module('Integration | Modifier | on-resize', function (hooks) {
   setupRenderingTest(hooks);
 
-  hooks.beforeEach(function () {
-    sinon.stub(window, 'requestAnimationFrame').callsFake(callback => callback());
-  });
-
   test('it works', async function (assert) {
     this.onResize = sinon.spy().named('onResize');
 
@@ -142,9 +138,8 @@ module('Integration | Modifier | on-resize', function (hooks) {
     assert.spy(callback2).calledOnce();
   });
 
-  test('prevents ResizeObserver loop limit related errors', async function (assert) {
+  test('prevents "ResizeObserver loop limit exceeded" error', async function (assert) {
     assert.expect(0);
-    window.requestAnimationFrame.restore();
     this.onResize = () => this.set('showText', true);
 
     await render(hbs`

--- a/tests/unit/services/resize-observer-test.js
+++ b/tests/unit/services/resize-observer-test.js
@@ -202,16 +202,6 @@ module('Unit | Service | resize-observer', function (hooks) {
       this.disconnectSpy = sinon.stub(this.service.observer, 'disconnect');
     });
 
-    test('cancels animation frame', function (assert) {
-      const { service } = this;
-      const cancelAFSpy = sinon.stub(window, 'cancelAnimationFrame');
-
-      sinon.stub(this.service, 'rafID').value(123);
-      service.clear();
-
-      assert.spy(cancelAFSpy).calledOnce().calledWithExactly([123]);
-    });
-
     test('resets callbacks map and unobserve all elements', function (assert) {
       const { service, serviceCallbacks, disconnectSpy } = this;
 
@@ -236,7 +226,6 @@ module('Unit | Service | resize-observer', function (hooks) {
     hooks.beforeEach(function () {
       const service = this.owner.lookup('service:resize-observer');
       sinon.stub(service.observer, 'observe');
-      sinon.stub(window, 'requestAnimationFrame').callsFake(callback => callback());
 
       const banner = document.createElement('div');
       banner.callbacks = [

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -15,5 +15,5 @@ export function setSize(el, { width, height }) {
     el.style.height = `${height}px`;
   }
 
-  return delay(50);
+  return delay(60);
 }


### PR DESCRIPTION
The RAF approach for preventing the RO loop limit error (#1) causes a noticeable initial render delay.

"ResizeObserver loop limit exceeded" error is fired as an `error` event at `window` object, whenever resize is triggered by the RO callback. The error is safe to ignore as it is just a warning message, telling that the "looping" callback will be skipped in the current frame, and will be called in the next one. We need to ignore it to prevent failing Ember tests.